### PR TITLE
Implement basic user service

### DIFF
--- a/BookPlatform.Core/Auth/Models/User.cs
+++ b/BookPlatform.Core/Auth/Models/User.cs
@@ -1,0 +1,9 @@
+namespace BookPlatform.Core.Auth.Models;
+
+public class User
+{
+    public Guid Id { get; set; }
+    public string Username { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string PasswordHash { get; set; } = string.Empty;
+}

--- a/BookPlatform.Core/Auth/Queries/UserQueries.cs
+++ b/BookPlatform.Core/Auth/Queries/UserQueries.cs
@@ -1,0 +1,16 @@
+namespace BookPlatform.Core.Auth.Queries;
+
+public static class UserQueries
+{
+    public const string Insert = @"INSERT INTO users (username, email, password_hash)
+                                     VALUES (@Username, @Email, @PasswordHash)
+                                     RETURNING id;";
+
+    public const string Update = @"UPDATE users
+                                     SET username = @Username,
+                                         email = @Email,
+                                         password_hash = @PasswordHash
+                                     WHERE id = @Id;";
+
+    public const string Delete = @"DELETE FROM users WHERE id = @Id;";
+}

--- a/BookPlatform.Core/Auth/Services/UserService.cs
+++ b/BookPlatform.Core/Auth/Services/UserService.cs
@@ -1,0 +1,48 @@
+using System.Data;
+using Dapper;
+using BookPlatform.Core.Auth.Models;
+using BookPlatform.Core.Auth.Queries;
+
+namespace BookPlatform.Core.Auth.Services;
+
+public interface IUserService
+{
+    Task<Guid> CreateUserAsync(User user, CancellationToken cancellationToken = default);
+    Task UpdateUserAsync(User user, CancellationToken cancellationToken = default);
+    Task DeleteUserAsync(Guid userId, CancellationToken cancellationToken = default);
+}
+
+public class UserService : IUserService
+{
+    private readonly IDbConnection _dbConnection;
+
+    public UserService(IDbConnection dbConnection)
+    {
+        _dbConnection = dbConnection;
+    }
+
+    public async Task<Guid> CreateUserAsync(User user, CancellationToken cancellationToken = default)
+    {
+        var id = await _dbConnection.ExecuteScalarAsync<Guid>(new CommandDefinition(
+            UserQueries.Insert,
+            new { user.Username, user.Email, user.PasswordHash },
+            cancellationToken: cancellationToken));
+        return id;
+    }
+
+    public async Task UpdateUserAsync(User user, CancellationToken cancellationToken = default)
+    {
+        await _dbConnection.ExecuteAsync(new CommandDefinition(
+            UserQueries.Update,
+            new { user.Id, user.Username, user.Email, user.PasswordHash },
+            cancellationToken: cancellationToken));
+    }
+
+    public async Task DeleteUserAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        await _dbConnection.ExecuteAsync(new CommandDefinition(
+            UserQueries.Delete,
+            new { Id = userId },
+            cancellationToken: cancellationToken));
+    }
+}

--- a/BookPlatform.Core/BookPlatform.Core.csproj
+++ b/BookPlatform.Core/BookPlatform.Core.csproj
@@ -5,5 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Dapper" Version="2.1.28" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- define `User` model
- add SQL query constants in `Auth/Queries`
- implement `UserService` for create/update/delete operations
- add Dapper dependency

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841dd69afec832fba375c07ab1a41f1