### PR TITLE
Add user business logic to docs

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -50,4 +50,35 @@ All services are independently scalable, containerized, and follow clean API pri
    ```bash
    git clone https://github.com/arashzitaly/book-platform-backend.git
    cd book-platform-backend
-asdfghjk
+   ```
+
+2. **Build and run**
+   ```bash
+   dotnet build
+   dotnet run --project BookPlatform.Api
+   ```
+
+## 👤 User Roles & Business Logic
+
+Planner supports **Owners** and **Customers**. Owners manage facilities, resources, slots, and can create guest bookings. Customers browse available resources and book their own time slots.
+
+### Facility Types
+
+- **Restaurant** – Reserve specific tables
+- **Clinic** – Book appointments with doctors (optional visit reason)
+- **Gym** – Reserve class spots (active membership required)
+- **Agency** – Schedule consultations or services
+
+### Booking Features
+
+- Registered customers can make, view, and cancel their bookings
+- Owners and staff can create guest bookings for walk-ins or phone requests
+- Bookings cannot be transferred between accounts
+
+### Gym Membership Requirement
+
+For gym facilities, users must have an **active membership** covering the booking date in order to reserve a slot. Owners may still register guest bookings for non-members.
+
+### Owner Dashboard
+
+Owners can view bookings by resource, filter by date or customer, and optionally view utilization statistics.


### PR DESCRIPTION
## Summary
- expand documentation with user roles and booking logic
- fix setup instructions

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841defc2ab4832fbf95691bb1d88f8e